### PR TITLE
CSS groundwork: Add colour variables and set font

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,7 @@
 body {
+  @import url('https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300..900;1,300..900&display=swap');
+  font-family: 'Rubik', system-ui, -apple-system, sans-serif;
+
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,12 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  --bkg-primary-color: #0b131e;
+  --bkg-secondary-color: #202b3b;
+  --text-primary-color: #f0f1f1;
+  --text-secondary-color: #9399a2;
+  --cta-primary-color: #0095ff;
 }
 
 code {


### PR DESCRIPTION
### Summary
During design, we chose [Rubik](https://fonts.google.com/selection?query=rubik) as our font. This PR imports Rubik at the top level CSS file from Google Fonts. It also sets up the variables we had established in Figma.